### PR TITLE
Arrumado nome das colunas do schema SQL

### DIFF
--- a/schemas/schema.sql
+++ b/schemas/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE Banks (
     Type VARCHAR(30) NULL,
     PixType VARCHAR(4) NULL,
     Url VARCHAR(255) NULL,
-    DateOperationStart CHAR(10) NULL,
-    DatePixStart CHAR(10) NULL,
+    DateOperationStarted CHAR(10) NULL,
+    DatePixStarted CHAR(10) NULL,
     DateRegistered DATETIME NOT NULL,
     DateUpdated DATETIME NOT NULL);


### PR DESCRIPTION
As colunas do schema SQL não estavam batendo com o nome do script SQL assim causando um erro na hora de executar, revisei nos outros schemas e aparentemente apenas o schema SQL estava com o nome da coluna errado.

Close #92 