### PR TITLE
Python schema: Ensure datetime fields is converted to datetime type

### DIFF
--- a/schemas/python.py
+++ b/schemas/python.py
@@ -38,7 +38,10 @@ def from_union(fs, x):
 
 
 def from_datetime(x: Any) -> datetime:
-    return dateutil.parser.parse(x)
+    assert isinstance(x, str)
+    obj_datetime = dateutil.parser.parse(x)
+    assert isinstance(obj_datetime, datetime)
+    return obj_datetime
 
 
 def from_bool(x: Any) -> bool:


### PR DESCRIPTION
Garante que o tipo da informação que entra é um `str` e o tipo da informação da saída, depois do parse, é um `datetime`.