### PR TITLE
Add repository name to checkout action

### DIFF
--- a/.github/workflows/daily-updates.yml
+++ b/.github/workflows/daily-updates.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout MergeTool
         uses: actions/checkout@v3
         with:
+          repo: guibranco/BancosBrasileiros
           ref: MergeTool
 
       - name: Setup .NET


### PR DESCRIPTION
Add the repository name to the checkout action so it won't broke on forks