### PR TITLE
 Implementado filtro de busca baseado nos 3 dígitos do código COMPE - Examplo .NET

### DIFF
--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -30,10 +30,10 @@
             Console.Write("Buscar COMPE (3 dígitos): ");
             var compe = Console.ReadLine();
 
-            filterBanks(compe);
+            FilterBanks(compe);
         }
 
-        private static void filterBanks(string compe)
+        private static void FilterBanks(string compe)
         {
             Console.Clear();
 
@@ -73,7 +73,7 @@
                 Console.Clear();
                 Console.Write("Buscar COMPE (3 dígitos): ");
                 compe = Console.ReadLine();
-                filterBanks(compe);
+                FilterBanks(compe);
             }
         }
     }

--- a/examples/dotnet/Program.cs
+++ b/examples/dotnet/Program.cs
@@ -3,16 +3,15 @@
     using BancosBrasileiros;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     class Program
     {
-        static void Main(string[] _)
+        private static string fileContent = System.IO.File.ReadAllText("banks.json");
+        private static List<Bank> banks = Newtonsoft.Json.JsonConvert.DeserializeObject<List<Bank>>(fileContent);
+        static void Main()
         {
             Console.WriteLine("Hello World!");
-
-            var fileContent = System.IO.File.ReadAllText("banks.json");
-            var banks = Newtonsoft.Json.JsonConvert.DeserializeObject<List<Bank>>(fileContent);
-
             Console.WriteLine($"Banks: {banks.Count}");
             foreach(var bank in banks)
             {
@@ -25,9 +24,57 @@
                 Console.WriteLine($"\tTED/DOC: {bank.CreditDocument??false}");
                 Console.WriteLine($"\tPIX: {bank.PixType??"False"}");
                 Console.WriteLine($"\tPortabilidade: {bank.SalaryPortability??"False"}");
-                Console.WriteLine($"\tAtualizado em: {bank.DateUpdated}");
+                Console.WriteLine($"\tAtualizado em: {bank.DateUpdated}\n");
             }
-            Console.ReadKey();
+
+            Console.Write("Buscar COMPE (3 dígitos): ");
+            var compe = Console.ReadLine();
+
+            filterBanks(compe);
+        }
+
+        private static void filterBanks(string compe)
+        {
+            Console.Clear();
+
+            var sortedBanks = banks.Where(b => b.Compe == compe);
+
+            if (sortedBanks.Count() != 0) 
+            {
+                foreach (var bank in sortedBanks)
+                {
+                    Console.ForegroundColor = ConsoleColor.Magenta;
+                    Console.WriteLine($"{bank.Compe}\t[CNPJ: {bank.Document}]\t{bank.LongName}");
+                    Console.ForegroundColor = ConsoleColor.White;
+
+                    Console.WriteLine($"\tTipo: {bank.Type ?? ""}");
+                    Console.WriteLine($"\tBoleto: {bank.Charge ?? false}");
+                    Console.WriteLine($"\tTED/DOC: {bank.CreditDocument ?? false}");
+                    Console.WriteLine($"\tPIX: {bank.PixType ?? "False"}");
+                    Console.WriteLine($"\tPortabilidade: {bank.SalaryPortability ?? "False"}");
+                    Console.WriteLine($"\tAtualizado em: {bank.DateUpdated} \n");
+                }
+            }
+            else
+            {
+                Console.WriteLine("Nenhum Resultado Encontrado.");
+            }
+
+            Console.Write("1.Listar Todos \t 2.Buscar COMPE: ");
+            int option = Convert.ToInt32(Console.ReadLine());
+
+            if(option == 1)
+            {
+                Console.Clear();
+                Main();
+            }
+            if(option == 2)
+            {
+                Console.Clear();
+                Console.Write("Buscar COMPE (3 dígitos): ");
+                compe = Console.ReadLine();
+                filterBanks(compe);
+            }
         }
     }
 }


### PR DESCRIPTION
Incorporado um sistema simples de filtragem que permite ao usuário buscar na lista com base nos 3 dígitos do COMPE. Além de um menu intuitivo com as opções "Listar Todos" e "Buscar por COMPE", aprimorando a funcionalidade geral do sistema.