### PR TITLE
fix: remove broken Snyk vulnerability badge links (410 Gone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml/badge.svg" alt="Daily updates"></a>
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml/badge.svg" alt="Link checker"></a>
   <a href="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros"><img src="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros/badge" alt="CodeFactor"></a>
-  <a href="https://snyk.io/test/github/guibranco/BancosBrasileiros"><img src="https://snyk.io/test/github/guibranco/BancosBrasileiros/badge.svg?style=plastic" alt="Known Vulnerabilities"></a>
   <a href="https://github.com/guibranco/bancosbrasileiros/issues"><img src="https://img.shields.io/github/issues/guibranco/bancosbrasileiros" alt="GitHub issues"></a>
 </p>
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -19,7 +19,6 @@
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml/badge.svg" alt="Daily updates"></a>
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml/badge.svg" alt="Link checker"></a>
   <a href="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros"><img src="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros/badge" alt="CodeFactor"></a>
-  <a href="https://snyk.io/test/github/guibranco/BancosBrasileiros"><img src="https://snyk.io/test/github/guibranco/BancosBrasileiros/badge.svg?style=plastic" alt="Known Vulnerabilities"></a>
   <a href="https://github.com/guibranco/bancosbrasileiros/issues"><img src="https://img.shields.io/github/issues/guibranco/bancosbrasileiros" alt="GitHub issues"></a>
 </p>
 


### PR DESCRIPTION
Fixes broken Snyk vulnerability badge links that return HTTP 410 Gone, as reported by the automated link checker.

## Changes
- Removed deprecated Snyk badge from README.md
- Removed deprecated Snyk badge from README.pt-br.md

The Snyk integration at snyk.io/test/github/guibranco/BancosBrasileiros returns 410 Gone.

Closes #944

Generated with Claude Code

## Summary by Sourcery

Remove deprecated Snyk vulnerability badges from project documentation.

Documentation:
- Remove broken Snyk vulnerability badge from the main README.
- Remove broken Snyk vulnerability badge from the Portuguese README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Snyk "Known Vulnerabilities" status badge from README and Portuguese README documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->