### PR TITLE
fix: replace broken Snyk vulnerability badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml/badge.svg" alt="Daily updates"></a>
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml/badge.svg" alt="Link checker"></a>
   <a href="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros"><img src="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros/badge" alt="CodeFactor"></a>
-  <a href="https://snyk.io/test/github/guibranco/BancosBrasileiros"><img src="https://snyk.io/test/github/guibranco/BancosBrasileiros/badge.svg?style=plastic" alt="Known Vulnerabilities"></a>
+  <a href="https://github.com/guibranco/BancosBrasileiros/security"><img src="https://img.shields.io/github/vulnerabilities/guibranco/BancosBrasileiros" alt="Known Vulnerabilities"></a>
   <a href="https://github.com/guibranco/bancosbrasileiros/issues"><img src="https://img.shields.io/github/issues/guibranco/bancosbrasileiros" alt="GitHub issues"></a>
 </p>
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -19,7 +19,7 @@
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml/badge.svg" alt="Daily updates"></a>
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml/badge.svg" alt="Link checker"></a>
   <a href="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros"><img src="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros/badge" alt="CodeFactor"></a>
-  <a href="https://snyk.io/test/github/guibranco/BancosBrasileiros"><img src="https://snyk.io/test/github/guibranco/BancosBrasileiros/badge.svg?style=plastic" alt="Known Vulnerabilities"></a>
+  <a href="https://github.com/guibranco/BancosBrasileiros/security"><img src="https://img.shields.io/github/vulnerabilities/guibranco/BancosBrasileiros" alt="Known Vulnerabilities"></a>
   <a href="https://github.com/guibranco/bancosbrasileiros/issues"><img src="https://img.shields.io/github/issues/guibranco/bancosbrasileiros" alt="GitHub issues"></a>
 </p>
 


### PR DESCRIPTION
Closes #943

## 📋 Description
The Snyk vulnerability badge URLs were returning 410 Gone as the Snyk public badge API has been permanently removed. Replaced with the GitHub security badge alternative in both README.md and README.pt-br.md.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## 💥 Does this introduce a breaking change?
- [ ] Yes
- [x] No

## ℹ️ Additional Information
Removed broken Snyk badge and replaced with working GitHub vulnerabilities shield badge. No functional code changes — documentation only.

## Summary by Sourcery

Documentation:
- Replace broken Snyk vulnerability badges with GitHub vulnerabilities shields in both English and Portuguese READMEs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Known Vulnerabilities badge in README files to link to GitHub security instead of an external service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->