### PR TITLE
fix(docs): drop dead Snyk vulnerability badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml/badge.svg" alt="Daily updates"></a>
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml/badge.svg" alt="Link checker"></a>
   <a href="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros"><img src="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros/badge" alt="CodeFactor"></a>
-  <a href="https://snyk.io/test/github/guibranco/BancosBrasileiros"><img src="https://snyk.io/test/github/guibranco/BancosBrasileiros/badge.svg?style=plastic" alt="Known Vulnerabilities"></a>
   <a href="https://github.com/guibranco/bancosbrasileiros/issues"><img src="https://img.shields.io/github/issues/guibranco/bancosbrasileiros" alt="GitHub issues"></a>
 </p>
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -19,7 +19,6 @@
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/daily-updates.yml/badge.svg" alt="Daily updates"></a>
   <a href="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml"><img src="https://github.com/guibranco/BancosBrasileiros/actions/workflows/link-checker.yml/badge.svg" alt="Link checker"></a>
   <a href="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros"><img src="https://www.codefactor.io/repository/github/guibranco/BancosBrasileiros/badge" alt="CodeFactor"></a>
-  <a href="https://snyk.io/test/github/guibranco/BancosBrasileiros"><img src="https://snyk.io/test/github/guibranco/BancosBrasileiros/badge.svg?style=plastic" alt="Known Vulnerabilities"></a>
   <a href="https://github.com/guibranco/bancosbrasileiros/issues"><img src="https://img.shields.io/github/issues/guibranco/bancosbrasileiros" alt="GitHub issues"></a>
 </p>
 


### PR DESCRIPTION
Closes the Snyk side of the link-checker report in #941.

The 'Known Vulnerabilities' badge in both README files links to Snyk endpoints that return `410 Gone`:

```
$ curl -sL -o /dev/null -w "%{http_code}\n" "https://snyk.io/test/github/guibranco/BancosBrasileiros"
410

$ curl -sL -o /dev/null -w "%{http_code}\n" "https://snyk.io/test/github/guibranco/BancosBrasileiros/badge.svg?style=plastic"
410
```

`410 Gone` means the resource has been permanently removed - Snyk no longer serves these per-repo public endpoints, so the badge image renders broken and the linked page is dead. There is no working replacement at the same URL.

Two cleanest options were:

1. Drop the badge.
2. Add `snyk\.io` to `.lycheeignore` and leave the broken badge in place.

I went with **(1)** because keeping a permanently broken image and a 410 link in the README is a worse reader experience than just removing the badge - the link checker would stop complaining either way.

The c6bank `403` error in #941 is left alone — `c6bank\.com\.br` is already in `.lycheeignore`, so that one's a transient bot issue rather than something to fix in code.

Refs #941.

This contribution was developed with AI assistance (Claude Code).

## Summary by Sourcery

Documentation:
- Remove the obsolete Snyk 'Known Vulnerabilities' badge from both English and Portuguese READMEs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Snyk "Known Vulnerabilities" badge from README files in English and Portuguese-Brazilian versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->